### PR TITLE
Relax version requirements for pyparsing and dateutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "slopescreening"
 dependencies =[
-    "pyparsing==2.4.7",
-    "python-dateutil==2.8.2",
+    "pyparsing>=2.4.7",
+    "python-dateutil>=2.8.2",
     "scikit-learn>=0.24.2",
     "matplotlib>=3.4.3",
 ]


### PR DESCRIPTION
These packages have strict version requirements. These seem unnecessarily strict and is causing some issues for me building on nix. All tests pass with the latest versions too, so I think they can be relaxed.